### PR TITLE
Mednext

### DIFF
--- a/monai/networks/blocks/__init__.py
+++ b/monai/networks/blocks/__init__.py
@@ -26,7 +26,7 @@ from .encoder import BaseEncoder
 from .fcn import FCN, GCN, MCFCN, Refine
 from .feature_pyramid_network import ExtraFPNBlock, FeaturePyramidNetwork, LastLevelMaxPool, LastLevelP6P7
 from .localnet_block import LocalNetDownSampleBlock, LocalNetFeatureExtractorBlock, LocalNetUpSampleBlock
-from .mednext_block import MedNeXtBlock, MedNeXtDownBlock, MedNeXtUpBlock, OutBlock
+from .mednext_block import MedNeXtBlock, MedNeXtDownBlock, MedNeXtOutBlock, MedNeXtUpBlock
 from .mlp import MLPBlock
 from .patchembedding import PatchEmbed, PatchEmbeddingBlock
 from .regunet_block import RegistrationDownSampleBlock, RegistrationExtractionBlock, RegistrationResidualConvBlock

--- a/monai/networks/nets/__init__.py
+++ b/monai/networks/nets/__init__.py
@@ -53,7 +53,25 @@ from .fullyconnectednet import FullyConnectedNet, VarFullyConnectedNet
 from .generator import Generator
 from .highresnet import HighResBlock, HighResNet
 from .hovernet import Hovernet, HoVernet, HoVerNet, HoverNet
-from .mednext import MedNeXt
+from .mednext import (
+    MedNeXt,
+    MedNext,
+    MedNextB,
+    MedNeXtB,
+    MedNextBase,
+    MedNextL,
+    MedNeXtL,
+    MedNeXtLarge,
+    MedNextLarge,
+    MedNextM,
+    MedNeXtM,
+    MedNeXtMedium,
+    MedNextMedium,
+    MedNextS,
+    MedNeXtS,
+    MedNeXtSmall,
+    MedNextSmall,
+)
 from .milmodel import MILModel
 from .netadapter import NetAdapter
 from .patchgan_discriminator import MultiScalePatchDiscriminator, PatchDiscriminator

--- a/tests/test_mednext.py
+++ b/tests/test_mednext.py
@@ -27,19 +27,17 @@ for spatial_dims in range(2, 4):
     for init_filters in [8, 16]:
         for deep_supervision in [False, True]:
             for do_res in [False, True]:
-                for do_res_up_down in [False, True]:
-                    test_case = [
-                        {
-                            "spatial_dims": spatial_dims,
-                            "init_filters": init_filters,
-                            "deep_supervision": deep_supervision,
-                            "do_res": do_res,
-                            "do_res_up_down": do_res_up_down,
-                        },
-                        (2, 1, *([16] * spatial_dims)),
-                        (2, 2, *([16] * spatial_dims)),
-                    ]
-                    TEST_CASE_MEDNEXT.append(test_case)
+                test_case = [
+                    {
+                        "spatial_dims": spatial_dims,
+                        "init_filters": init_filters,
+                        "deep_supervision": deep_supervision,
+                        "use_residual_connection": do_res,
+                    },
+                    (2, 1, *([16] * spatial_dims)),
+                    (2, 2, *([16] * spatial_dims)),
+                ]
+                TEST_CASE_MEDNEXT.append(test_case)
 
 TEST_CASE_MEDNEXT_2 = []
 for spatial_dims in range(2, 4):


### PR DESCRIPTION
Fixes # .

### Description

This pull request is intended to solve some of the issues pointed by @jzielke in the MONAI pull request [8004](https://github.com/Project-MONAI/MONAI/pull/8004). A lot of the updates come from the MONAI dev branch I'm using which is ahead of your mednext branch, but let me summarize the changes I made : 
- `nets/mednext.py` 
-- renamed MedNeXt arguments to follow @jzielke [recomendations](https://github.com/Project-|MONAI/MONAI/pull/8004#discussion_r1713951167)
-- linked residual units of the encoder and decoder with one `do_res` flag
-- add model variants (S, B, M, L) as described in the original paper
-- solved code formating issues and corrected the module imports as stated in https://github.com/Project-MONAI/MONAI/blob/dev/CONTRIBUTING.md#checking-the-coding-style
- `blocks/mednext_block.py`
-- removed the author defined LayerNorm and replaced it with torch.nn.LayerNorm as only the "channel_first" case is used in block and network definition . 
-- renamed `OutBlock` to `MedNeXtOutBlock` to avoid naming confusion as the block is accessible in the API
-- fixing module class export
- `test/test_mednext.py`
-- removed all the `do_res_up_down` test cases as `do_res_up_down` as been fused with `do_res` arguments
- `__init__.py`
-- made available the different versions of MedNext to the API as done by [DenseNet](https://github.com/Project-MONAI/MONAI/blob/cea80a686b907b22d90c8024cea5a17ef9d9f58a/monai/networks/nets/densenet.py)

I should add some tests for the `mednext_block.py` script and evaluate the performance of the model on a benchmark used by the author (BTCV or AMOS22). I also tested all the basic unit test and they all pass so you don't have to do it `./runtests.sh --quick --unittests  --disttests`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
